### PR TITLE
feat(widgets): Add GameTitle widget

### DIFF
--- a/lib/flutter_shared_components.dart
+++ b/lib/flutter_shared_components.dart
@@ -1,4 +1,5 @@
 export 'app/soloscripted_app.dart';
 export 'screens/home_screen.dart';
 export 'widgets/badged_action_button.dart';
+export 'widgets/game_title.dart';
 export 'widgets/styled_action_button.dart';

--- a/lib/widgets/game_title.dart
+++ b/lib/widgets/game_title.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+class GameTitle extends StatelessWidget {
+  final String logoAsset;
+  final String titlePart1;
+  final String titlePart2;
+  final Color titlePart1Color;
+  final Color? titlePart2Color;
+
+  const GameTitle({
+    super.key,
+    required this.logoAsset,
+    required this.titlePart1,
+    required this.titlePart2,
+    this.titlePart1Color = Colors.blue,
+    this.titlePart2Color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        _buildLogo(context),
+        const SizedBox(width: 12),
+        _buildTitle(context),
+      ],
+    );
+  }
+
+  Widget _buildLogo(BuildContext context) {
+    return Container(
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: Colors.black87,
+        borderRadius: BorderRadius.circular(8.0),
+        boxShadow: [
+          BoxShadow(
+            color: Theme.of(context).colorScheme.shadow.withAlpha(102),
+            blurRadius: 4,
+            offset: const Offset(2, 2),
+          ),
+        ],
+      ),
+      child: Image.asset(
+        logoAsset,
+        height: 64,
+        errorBuilder: (context, error, stackTrace) {
+          return const Icon(
+            Icons.code_sharp,
+            size: 64,
+            color: Colors.white,
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildTitle(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return RichText(
+      text: TextSpan(
+        style: Theme.of(context).textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
+        children: <TextSpan>[
+          TextSpan(text: titlePart1, style: TextStyle(color: titlePart1Color)),
+          TextSpan(text: titlePart2, style: TextStyle(color: titlePart2Color ?? colorScheme.onSurface)),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This commit introduces a new reusable GameTitle widget.

The widget is designed to display a logo alongside a two-part title, allowing for different styling for each part of the title. It's composed of a Row containing a styled image for the logo and a RichText widget for the title.

Key features include:

A styled logo container with a shadow, background color, and rounded corners. An errorBuilder for the logo to handle missing assets gracefully by displaying a fallback icon. A two-part title using RichText for separate color styling on each part. Customizable properties for the logo asset, title text, and colors. This component promotes a consistent look and feel for titles within applications using this shared component library.