### PR TITLE
feat(app): Wait for ATT authorization before showing home screen

### DIFF
--- a/lib/app/soloscripted_app.dart
+++ b/lib/app/soloscripted_app.dart
@@ -23,12 +23,21 @@ class SoloScriptedApp extends StatefulWidget {
 }
 
 class _SoloScriptedAppState extends State<SoloScriptedApp> {
+  bool _isReady = false;
+
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _requestTrackingAuthorization();
-    });
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    await _requestTrackingAuthorization();
+    if (mounted) {
+      setState(() {
+        _isReady = true;
+      });
+    }
   }
 
   Future<void> _requestTrackingAuthorization() async {
@@ -53,9 +62,11 @@ class _SoloScriptedAppState extends State<SoloScriptedApp> {
       ),
       localizationsDelegates: widget.localizationsDelegates,
       supportedLocales: widget.supportedLocales,
-      home: HomeScreen(
-        nextScreen: widget.mainScreen,
-      ),
+      home: _isReady
+          ? HomeScreen(
+              nextScreen: widget.mainScreen,
+            )
+          : const Scaffold(body: Center(child: CircularProgressIndicator())),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_shared_components
 description: "A collection of reusable Flutter widgets and screens designed to be easily integrated into your projects."
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/SoloScripted/flutter-shared-components
 repository: https://github.com/SoloScripted/flutter-shared-components
 publish_to: 'none' # Prevent accidental publishing to pub.dev


### PR DESCRIPTION
Introduces a loading state to the `SoloScriptedApp` widget to ensure the application waits for the user to respond to the App Tracking Transparency (ATT) permission dialog.

Previously, the `HomeScreen` would be displayed immediately at startup, with the ATT dialog appearing over it.

This change modifies the initialization logic to:
- Await the completion of the `requestTrackingAuthorization` method.
- Display a `CircularProgressIndicator` while waiting for the user's input.
- Only navigate to the `HomeScreen` after the authorization status has been determined.

This creates a more sequential and user-friendly startup flow, respecting the user's privacy decision before proceeding into the main application.